### PR TITLE
Update consensus-datastructures.md

### DIFF
--- a/fundamentals/specs/consensus-datastructures.md
+++ b/fundamentals/specs/consensus-datastructures.md
@@ -2,21 +2,21 @@
 
 ```text
 Block =
-	ParentHash: BlockHash,
-	UncleHash: BlockHash[],
-	MinerAddress: Address,
-	StateRoot: StateRoot,
-	TransactionRoot: TransactionRoot,
-	TransactionReceiptRoot: TransactionReceiptRoot,
-	LogsBloom: BloomFilter,
-	Difficulty: UInt256,
-	Number: UInt256,
-	GasLimit: UInt64,
-	GasUsed: UInt64,
-	Timestamp: UInt256,
-	ExtraData: UInt8[32],
-	ProofOfWork: Keccak256, // AKA: MixHash; AKA: MixDigest
-	Nonce: UInt8[8],
+	ParentHash: BlockHash
+	UncleHash: BlockHash[]
+	MinerAddress: Address
+	StateRoot: StateRoot
+	TransactionRoot: TransactionRoot
+	TransactionReceiptRoot: TransactionReceiptRoot
+	LogsBloom: Bytes256
+	Difficulty: UInt256
+	Number: UInt256
+	GasLimit: UInt64
+	GasUsed: UInt64
+	Timestamp: UInt256
+	ExtraData: UInt256
+	ProofOfWork: Bytes32 // AKA: MixHash; AKA: MixDigest
+	Nonce: Bytes8
 ```
 
 ```text
@@ -24,24 +24,27 @@ BlockHash = keccak256(rlp(Block))
 ```
 
 ```text
-StateRoot = patriciaTree(keccak256(Address) => rlp(
-	Nonce,
-	Balance,
-	StorageRoot,
-	CodeHash,
-))
+StateRoot = patriciaTrie(keccak256(Address) => rlp(Account)).rootHash
 ```
 
 ```text
-StorageRoot = patriciaTree(UInt256 => UInt256)
+StorageRoot = patriciaTrie(keccak256(StorageSlot: UInt256) => Bytes32).rootHash
 ```
 
 ```text
-TransactionRoot = patriciaTree(rlp(TransactionIndexInBlock) => rlp(Transaction)).rootHash
+TransactionRoot = patriciaTrie(rlp(TransactionIndexInBlock) => rlp(Transaction)).rootHash
 ```
 
 ```text
-TransactionReceiptRoot = patriciaTree(rlp(TransactionIndexInBlock) => rlp(TransactionReceipt)).rootHash
+TransactionReceiptRoot = patriciaTrie(rlp(TransactionIndexInBlock) => rlp(TransactionReceipt)).rootHash
+```
+
+```text
+Account =
+	Nonce: UInt64
+	Balance: UInt256
+	StorageRoot: Bytes32
+	CodeHash: Bytes32
 ```
 
 ```text
@@ -50,7 +53,7 @@ Transaction =
 	Price: UInt256
 	GasLimit: UInt64
 	Amount: UInt256
-	Payload: UInt8[]
+	Payload: Bytes
 	V: UInt256
 	R: UInt256
 	S: UInt256
@@ -58,8 +61,15 @@ Transaction =
 
 ```text
 TransactionReceipt =
-	PostStateOrStatus: StateRoot|UInt32, // TODO: figure out what this union actually means
-	CumulativeGasUsed: UInt64,
-	LogsBloom: BloomFilter,
-	Logs: Log[],
+	CumulativeGasUsed: UInt64
+	LogsBloom: Bytes256
+	Logs: Log[]
+	PostStateOrStatus: UInt32
+```
+
+```text
+Log =
+	LoggerAddress: Address
+	LogTopics: Bytes32[]
+	LogData: Bytes
 ```


### PR DESCRIPTION
* Adds `Log`
* Extracts `Account`
* Switches to using `Bytes`, `Bytes32` and `Bytes8` as appropriate (in Ethereum, the RLP encoding of `Bytes32` is different from the RLP encoding of `UInt256`)
* Added some missing `.rootHash` to the patriciaTries
* Corrects spelling of `patriciaTree` to `patriciaTrie`