### PR TITLE
correct ECDSA signature `r` and `s` value encodings

### DIFF
--- a/json-rpc/api.md
+++ b/json-rpc/api.md
@@ -1260,8 +1260,8 @@ params: [
   - `transactionIndex`: `QUANTITY` - integer of the transactions index position in the block. `null` when its pending.
   - `value`: `QUANTITY` - value transferred in Wei.
   - `v`: `QUANTITY` - ECDSA recovery id
-  - `r`: `DATA`, 32 Bytes - ECDSA signature r
-  - `s`: `DATA`, 32 Bytes - ECDSA signature s
+  - `r`: `QUANTITY` - ECDSA signature r
+  - `s`: `QUANTITY` - ECDSA signature s
 
 ##### Example
 ```js


### PR DESCRIPTION
These values were previously corrected on the GitHub wiki, but the change was reverted when "upgrading" (:sweat_smile:) to the new wiki.js wiki.