### PR TITLE
remove erroneous characters from eth_getBlockTransactionCountByNumber spec

### DIFF
--- a/json-rpc/api.md
+++ b/json-rpc/api.md
@@ -753,7 +753,7 @@ curl -X POST --data '{"jsonrpc":"2.0","method":"eth_getBlockTransactionCountByHa
 ***
 
 #### eth_getBlockTransactionCountByNumber
-> >
+
 Returns the number of transactions in a block matching the given block number.
 
 


### PR DESCRIPTION
This fix will remove this quote block form the rendered page:

![image](https://user-images.githubusercontent.com/187813/91101715-a985e100-e635-11ea-8b70-883721ebdbbf.png)
